### PR TITLE
Added rate limiter on RPC calls. Defaulted notify and execute_liquidation to True.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ __pycache__/
 *.pyd
 
 /redstone_script/node_modules
+
+.flaskenv

--- a/README.md
+++ b/README.md
@@ -160,3 +160,46 @@ forge script test/LiquidationSetupWithVaultCreated.sol --rpc-url $RPC_URL --broa
 ```
 
 This test is intended to create a position on an existing vault. To test a liquitation, you can either wait for price fluctuations to happen or manually change the LTV of the vault using the create.euler.finance UI if it is a governed vault that you control.
+
+## To run the liquidation bot
+
+Added /etc/systemd/system/liquidation-bot.service
+```
+[Unit]
+Description=Liquidation Bot Service
+After=network.target
+
+[Service]
+User=admin
+WorkingDirectory=/home/admin/liq-bot-v2
+Environment="PATH=/home/admin/liq-bot-v2/venv/bin"
+Environment="FLASK_APP=application.py"
+Environment="FLASK_RUN_HOST=0.0.0.0"
+Environment="FLASK_RUN_PORT=8080"
+Environment="FLASK_ENV=production"
+Environment="FLASK_DEBUG=False"
+
+# Using flask instead of python3
+ExecStart=/home/admin/liq-bot-v2/venv/bin/flask run --host=0.0.0.0 --port=8080
+
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Reload systemd:
+```
+sudo systemctl daemon-reload
+```
+
+Then run with:
+```
+sudo systemctl start liquidation-bot.service
+```
+
+Check status with:
+```
+sudo systemctl status liquidation-bot.service
+```

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -77,7 +77,7 @@ global:
   # API Retry
   NUM_RETRIES: 3
   RETRY_DELAY: 10
-  # Acceptable amound of overswapping of collateral for 1INCH binary search
+  # Acceptable amount of overswapping of collateral for 1INCH binary search
   API_REQUEST_DELAY: .25
   SWAP_SLIPPAGE: 1.0 # 1%
   SWAP_DEADLINE: 300 # 5 minutes

--- a/app/liquidation/bot_manager.py
+++ b/app/liquidation/bot_manager.py
@@ -22,7 +22,7 @@ class ChainManager:
 
     def _initialize_chains(self):
         """Initialize components for each chain"""
-        print(self.chain_ids)
+        print("Chain IDs: ", self.chain_ids)
         for chain_id in self.chain_ids:
             # Load chain-specific config
             config = load_chain_config(chain_id)

--- a/app/liquidation/liquidation_bot.py
+++ b/app/liquidation/liquidation_bot.py
@@ -98,7 +98,7 @@ class Vault:
                 collateral_value, liability_value = PullOracleHandler.get_account_values_with_redstone_batch_simulation(
                     self, account_address, self.redstone_feed_ids, self.config)
             else:
-                logger.info("Vault: Getting account liquidity normally for vault %s", self.address)
+                logger.info("Vault:  %s", self.address)
                 (collateral_value, liability_value) = self.instance.functions.accountLiquidity(
                     Web3.to_checksum_address(account_address),
                     True
@@ -368,7 +368,7 @@ class AccountMonitor:
     updates, triggering liquidations, and managing the overall state of the
     monitored accounts. It also handles saving and loading the monitor's state.
     """
-    def __init__(self, chain_id: int, config: ChainConfig, notify = False, execute_liquidation = False):
+    def __init__(self, chain_id: int, config: ChainConfig, notify = True, execute_liquidation = True):
         self.chain_id = chain_id
         self.w3 = config.w3,
         self.config = config
@@ -660,23 +660,26 @@ class AccountMonitor:
         logger.info("Rebuilding queue based on current account health")
 
         self.update_queue = queue.PriorityQueue()
+        idx = 0
+        total_accounts = len(self.accounts)
         for address, account in self.accounts.items():
             try:
+                idx += 1
                 health_score = account.update_liquidity()
 
                 if account.current_health_score == math.inf:
-                    logger.info("AccountMonitor: %s has no borrow, skipping", address)
+                    logger.info("AccountMonitor: %s/%s %s ", idx, total_accounts, address)
                     continue
 
                 next_update_time = account.time_of_next_update
                 self.update_queue.put((next_update_time, address))
-                logger.info("AccountMonitor: %s added to queue"
+                logger.info("AccountMonitor: %s/%s %s added to queue"
                             " with health score %s, next update at %s",
-                            address, health_score, time.strftime("%Y-%m-%d %H:%M:%S",
+                            idx, total_accounts, address, health_score, time.strftime("%Y-%m-%d %H:%M:%S",
                                                                  time.localtime(next_update_time)))
             except Exception as ex: # pylint: disable=broad-except
-                logger.error("AccountMonitor: Failed to put account %s into rebuilt queue: %s",
-                             address, ex, exc_info=True)
+                logger.error("AccountMonitor: Failed to put account %s/%s %s into rebuilt queue: %s",
+                             idx, total_accounts, address, ex, exc_info=True)
 
         logger.info("AccountMonitor: Queue rebuilt with %s acccounts", self.update_queue.qsize())
 

--- a/app/liquidation/utils.py
+++ b/app/liquidation/utils.py
@@ -6,6 +6,8 @@ import json
 import functools
 import time
 import traceback
+import threading
+
 import requests
 
 from typing import Any, Callable, Dict, Optional
@@ -110,6 +112,27 @@ def retry_request(logger: logging.Logger,
         return wrapper
     return decorator
 
+def rate_limit(logger: logging.Logger,
+                  max_calls_per_second: int = loaded_config.MAX_CALLS_PER_SECOND):
+    """
+    Decorator to limit the number of calls to a function to max_calls_per_second.
+    """
+    lock = threading.Lock()
+    last_called = [0.0]
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with lock:
+                elapsed = time.time() - last_called[0]
+                wait_time = max(0, 1.0 / max_calls_per_second - elapsed)
+                logger.info(f"RL: waiting for {wait_time} seconds")
+                time.sleep(wait_time)
+                result = func(*args, **kwargs)
+                last_called[0] = time.time()
+                return result
+        return wrapper
+    return decorator
+
 def get_spy_link(account, config: ChainConfig):
     """
     Get account owner from EVC
@@ -125,6 +148,7 @@ def get_spy_link(account, config: ChainConfig):
     return spy_link
 
 @retry_request(logging.getLogger("liquidation_bot"))
+@rate_limit(logging.getLogger("liquidation_bot"))
 def make_api_request(url: str,
                      headers: Dict[str, str],
                      params: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/app/liquidation/utils.py
+++ b/app/liquidation/utils.py
@@ -113,9 +113,16 @@ def retry_request(logger: logging.Logger,
     return decorator
 
 def rate_limit(logger: logging.Logger,
-                  max_calls_per_second: int = loaded_config.MAX_CALLS_PER_SECOND):
+                  max_calls_per_second: int = 10):
     """
     Decorator to limit the number of calls to a function to max_calls_per_second.
+    Args:
+        logger (logging.Logger): Logger instance to log retry attempts.
+        max_calls_per_second (int, optional): Maximum number of retry attempts.
+                                    Defaults to config.MAX_CALLS_PER_SECOND.
+
+    Returns:
+        Callable: Decorated function.
     """
     lock = threading.Lock()
     last_called = [0.0]

--- a/shell_routines.txt
+++ b/shell_routines.txt
@@ -1,0 +1,6 @@
+forge script contracts/DeployLiquidator.sol --rpc-url https://eth-mainnet.g.alchemy.com/v2/ivS5Oiw2RjJMwvRaJiOaIG5-Wry-IVUj --broadcast --ffi -vvv --slow
+
+forge script test/LiquidationSetupWithVaultCreated.sol --rpc-url https://eth-mainnet.g.alchemy.com/v2/ivS5Oiw2RjJMwvRaJiOaIG5-Wry-IVUj --broadcast --ffi -vvv --slow --evm-version shanghai
+
+Display only the logs for a specific health score:
+tail -f logfile | grep "health score" | awk -F'health score: ' '{ split($2, arr, ","); if (arr[1] < 1.1) print $0 }'

--- a/shell_routines.txt
+++ b/shell_routines.txt
@@ -1,6 +1,0 @@
-forge script contracts/DeployLiquidator.sol --rpc-url https://eth-mainnet.g.alchemy.com/v2/ivS5Oiw2RjJMwvRaJiOaIG5-Wry-IVUj --broadcast --ffi -vvv --slow
-
-forge script test/LiquidationSetupWithVaultCreated.sol --rpc-url https://eth-mainnet.g.alchemy.com/v2/ivS5Oiw2RjJMwvRaJiOaIG5-Wry-IVUj --broadcast --ffi -vvv --slow --evm-version shanghai
-
-Display only the logs for a specific health score:
-tail -f logfile | grep "health score" | awk -F'health score: ' '{ split($2, arr, ","); if (arr[1] < 1.1) print $0 }'


### PR DESCRIPTION
Added a rate limiter decorator to limit the calls to RPC to 10 req/sec.
Changed the default values for `notify` and `execute_liquidation` to `True`.
Small typos correction.

